### PR TITLE
fix(tsconfig): use ES2017 target for TypeScript 7

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2017",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
## Summary
- TypeScript 7 removed `target=ES5` (`TS5108`), which caused `next build` typechecking to fail after the recent major upgrade.
- Update `tsconfig.json` `compilerOptions.target` to `ES2017` (Next.js-compatible default).

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes locally
- [ ] Note: `npm run lint` still fails due to `typescript-eslint` / `eslint-config-next` not supporting TypeScript 7.0 + ESLint 10 yet (ecosystem blocker, separate from this fix)